### PR TITLE
QA_ExportShapefiles.py - Fix syntax for iteration

### DIFF
--- a/QA_ExportShapefiles.py
+++ b/QA_ExportShapefiles.py
@@ -240,7 +240,7 @@ def GetExportLayers(inLoc):
                         pass
 
             # Check each SSURGO dataType in dictionary to make sure that there are no duplicates or omissisions
-            for lyr, iCnt in dCount.items():
+            for lyr, iCnt in list(dCount.items()):
 
                 # SSURGO layer is missing
                 if int(iCnt) == 0:


### PR DESCRIPTION
This is a fix for the following error when running the "Export to SSURGO Shapefile" certification tool

```
ERROR 001683: Found Python 2 to 3 errors: 
Line 243:             for lyr, iCnt in dCount.items(): ->             for lyr, iCnt in list(dCount.items()): 
within script tool QAExportShapefiles2_SSURGOQualityAssuranceTools(D:\workspace\SSURGO-QA-ArcGIS-Pro\QA_ExportShapefiles.py)
```